### PR TITLE
Don't split words on non-breaking space char

### DIFF
--- a/packages/vx-text/src/Text.js
+++ b/packages/vx-text/src/Text.js
@@ -25,7 +25,7 @@ class Text extends Component {
     // Only perform calculations if using features that require them (multiline, scaleToFit)
     if (props.width || props.scaleToFit) {
       if (needCalculate) {
-        const words = props.children ? props.children.toString().split(/\s+/) : [];
+        const words = props.children ? props.children.toString().split(/(?:(?!\u00A0+)\s+)/) : [];
 
         this.wordsWithComputedWidth = words.map(word => ({
           word,
@@ -46,7 +46,7 @@ class Text extends Component {
   }
 
   updateWordsWithoutCalculate(props) {
-    const words = props.children ? props.children.toString().split(/\s+/) : [];
+    const words = props.children ? props.children.toString().split(/(?:(?!\u00A0+)\s+)/) : [];
     this.setState({ wordsByLines: [{ words }] });
   }
 


### PR DESCRIPTION
#### :boom: Breaking Changes

- If strings were expected to be split by a non-breaking space character, they will now be rendered differently.

#### :rocket: Enhancements

- Don't split strings rendered by `<Text />` when encountering a set of non-breaking space characters.

#### :memo: Documentation

- Currency strings output by Number.toLocaleString, for example, can contain non-breaking space characters. The emitted SVG tspan elements should not be split by these characters.

#### :bug: Bug Fix

- N/A

#### :house: Internal

- N/A
